### PR TITLE
Android support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .DS_Store
 target/
 node_modules/
+engine.io-server/build

--- a/engine.io-server/build.gradle
+++ b/engine.io-server/build.gradle
@@ -1,0 +1,25 @@
+apply plugin: 'com.android.library'
+
+android {
+    lintOptions {
+        abortOnError false
+    }
+
+    defaultConfig {
+        targetSdkVersion 28
+        minSdkVersion 21
+    }
+
+    dependencies {
+        api ('io.socket:engine.io-client:1.0.0')
+        api group: 'javax.servlet', name: 'servlet-api', version: '2.5'
+    }
+
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+
+    compileSdkVersion project.hasProperty('global_compileSdkVersion') ? global_compileSdkVersion : 28
+    buildToolsVersion project.hasProperty('global_buildToolsVersion') ? global_buildToolsVersion : '28.0.3'
+}

--- a/engine.io-server/src/main/AndroidManifest.xml
+++ b/engine.io-server/src/main/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest package="io.socket.engineio.server">
+
+    <application>
+    </application>
+
+</manifest>

--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServer.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServer.java
@@ -5,6 +5,8 @@ import io.socket.engineio.server.transport.Polling;
 import io.socket.engineio.server.transport.WebSocket;
 import io.socket.yeast.ServerYeast;
 import io.socket.parseqs.ParseQS;
+
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import javax.servlet.http.HttpServletRequest;
@@ -92,7 +94,7 @@ public final class EngineIoServer extends Emitter {
             return;
         }
 
-        final String sid = query.getOrDefault("sid", null);
+        final String sid = query.get("sid");
         if (sid != null) {
             if(!mClients.containsKey(query.get("sid"))) {
                 sendErrorMessage(request, response, ServerErrors.UNKNOWN_SID);
@@ -120,7 +122,7 @@ public final class EngineIoServer extends Emitter {
      */
     public void handleWebSocket(EngineIoWebSocket webSocket) {
         final Map<String, String> query = webSocket.getQuery();
-        final String sid = query.getOrDefault("sid", null);
+        final String sid = query.get("sid");
 
         if(sid != null) {
             EngineIoSocket socket = mClients.get(sid);
@@ -161,17 +163,27 @@ public final class EngineIoServer extends Emitter {
                 response.addHeader("Access-Control-Allow-Headers", "origin, content-type, accept");
             }
 
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("code", code.getCode());
-            jsonObject.put("message", code.getMessage());
-            response.getWriter().write(jsonObject.toString());
+            try {
+                JSONObject jsonObject = new JSONObject();
+                jsonObject.put("code", code.getCode());
+                jsonObject.put("message", code.getMessage());
+                response.getWriter().write(jsonObject.toString());
+            }
+            catch (JSONException e) {
+                throw new AssertionError(e);
+            }
         } else {
             response.setStatus(403);
 
-            JSONObject jsonObject = new JSONObject();
-            jsonObject.put("code", ServerErrors.FORBIDDEN.getCode());
-            jsonObject.put("message", ServerErrors.FORBIDDEN.getMessage());
-            response.getWriter().write(jsonObject.toString());
+            try {
+                JSONObject jsonObject = new JSONObject();
+                jsonObject.put("code", ServerErrors.FORBIDDEN.getCode());
+                jsonObject.put("message", ServerErrors.FORBIDDEN.getMessage());
+                response.getWriter().write(jsonObject.toString());
+            }
+            catch (JSONException e) {
+                throw new AssertionError(e);
+            }
         }
     }
 

--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServer.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServer.java
@@ -173,6 +173,7 @@ public final class EngineIoServer extends Emitter {
                 response.getWriter().write(jsonObject.toString());
             }
             catch (JSONException e) {
+                // this catch block is a requirement on Android which embeds an older org.json
                 throw new AssertionError(e);
             }
         } else {
@@ -185,6 +186,7 @@ public final class EngineIoServer extends Emitter {
                 response.getWriter().write(jsonObject.toString());
             }
             catch (JSONException e) {
+                // this catch block is a requirement on Android which embeds an older org.json
                 throw new AssertionError(e);
             }
         }

--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
@@ -5,6 +5,7 @@ import io.socket.engineio.parser.Packet;
 import io.socket.engineio.server.transport.Polling;
 import io.socket.engineio.server.transport.WebSocket;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import javax.servlet.http.HttpServletRequest;
@@ -215,10 +216,15 @@ public final class EngineIoSocket extends Emitter {
         upgrades.put(WebSocket.NAME);
 
         JSONObject handshakePacket = new JSONObject();
-        handshakePacket.put("sid", mSid);
-        handshakePacket.put("upgrades", upgrades);
-        handshakePacket.put("pingInterval", mServer.getOptions().getPingInterval());
-        handshakePacket.put("pingTimeout", mServer.getOptions().getPingTimeout());
+        try {
+            handshakePacket.put("sid", mSid);
+            handshakePacket.put("upgrades", upgrades);
+            handshakePacket.put("pingInterval", mServer.getOptions().getPingInterval());
+            handshakePacket.put("pingTimeout", mServer.getOptions().getPingTimeout());
+        }
+        catch (JSONException e) {
+            throw new AssertionError(e);
+        }
 
         Packet<String> openPacket = new Packet<>(Packet.OPEN);
         openPacket.data = handshakePacket.toString();

--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
@@ -223,6 +223,7 @@ public final class EngineIoSocket extends Emitter {
             handshakePacket.put("pingTimeout", mServer.getOptions().getPingTimeout());
         }
         catch (JSONException e) {
+            // this catch block is a requirement on Android which embeds an older org.json
             throw new AssertionError(e);
         }
 

--- a/engine.io-server/src/main/java/io/socket/engineio/server/transport/Polling.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/transport/Polling.java
@@ -102,6 +102,7 @@ public final class Polling extends Transport {
                     contentBytes = contentString.getBytes(StandardCharsets.UTF_8);
                 }
                 catch (JSONException e) {
+                    // this catch block is a requirement on Android which embeds an older org.json
                     throw new AssertionError(e);
                 }
             } else {


### PR DESCRIPTION
Android uses an older version of org.json which throws exceptions on JSONObject.put. It never actually throws.
The change is to simply try/catch the JSONException and throw an assertion if anything is caught. I've literally never ever seen it thrown, so I'm unsure what would actually trigger it.
That exception seems to have been relaxed in newer versions of org.json.
It is not possible to replace the Android version of org.json via an external dependency. The framework version is always preferred.

The other change is to replace getOrDefault(key, null) with get, which is equivalent, and available on Android.
Android supports Java 8 language features on older runtimes (since it all compiled down to dalvik byte code), but not all the Java 8 libraries. getOrDefault is a Java8 method, and not available on Android.