### PR TITLE
Send a NOOP packet to complete the upgrade on the old transport.

### DIFF
--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
@@ -149,6 +149,11 @@ public final class EngineIoSocket extends Emitter {
                     add(replyPacket);
                 }});
 
+                final Packet<String> noopPacket = new Packet<>(Packet.NOOP);
+                mTransport.send(new ArrayList<Packet>(){{
+                    add(noopPacket);
+                }});
+
                 emit("upgrading", transport);
             } else if(packet.type.equals(Packet.UPGRADE) && (mReadyState != ReadyState.CLOSED) && (mReadyState != ReadyState.CLOSING)) {
                 cleanup.run();

--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
@@ -24,7 +24,7 @@ import java.util.TimerTask;
  */
 public final class EngineIoSocket extends Emitter {
 
-    private static final List<Packet> noopPayload = new ArrayList<Packet>() {{
+    private static final List<Packet> PAYLOAD_NOOP = new ArrayList<Packet>() {{
         add(new Packet<>(Packet.NOOP));
     }};
 
@@ -155,7 +155,7 @@ public final class EngineIoSocket extends Emitter {
                 }});
 
                 if (mTransport.isWritable()) {
-                    mTransport.send(noopPayload);
+                    mTransport.send(PAYLOAD_NOOP);
                 }
 
                 emit("upgrading", transport);

--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -22,6 +23,10 @@ import java.util.TimerTask;
  * one per object.
  */
 public final class EngineIoSocket extends Emitter {
+
+    private static final List<Packet> noopPayload = new ArrayList<Packet>() {{
+        add(new Packet<>(Packet.NOOP));
+    }};
 
     private final String mSid;
     private final EngineIoServer mServer;
@@ -149,10 +154,9 @@ public final class EngineIoSocket extends Emitter {
                     add(replyPacket);
                 }});
 
-                final Packet<String> noopPacket = new Packet<>(Packet.NOOP);
-                mTransport.send(new ArrayList<Packet>(){{
-                    add(noopPacket);
-                }});
+                if (mTransport.isWritable()) {
+                    mTransport.send(noopPayload);
+                }
 
                 emit("upgrading", transport);
             } else if(packet.type.equals(Packet.UPGRADE) && (mReadyState != ReadyState.CLOSED) && (mReadyState != ReadyState.CLOSING)) {


### PR DESCRIPTION
There is a bug with the engine.io upgrade negotiation. The bug is as follows:

Client starts XHR polling
Client starts websocket with upgrade request
Server responds with the upgrade response
Server is still holding the XHR open (no new data has been queued/sent to complete the request)
Client is not sending pings during the upgrade (not sure if this is by design, but the javascript client implementation is not)
Client does NOT confirm the upgrade with `Packet.UPGRADE` message. Seems to be hung on the pending XHR connection.
Server kills client due to ping timeout

Just a note on reproducing this: any data being sent on the transport by the server will result in the xhr request being completed/closed, and the upgrade being unblocked and completing successfully. This only occurs if the connection and upgrade is initiated and no data is sent for the duration of a ping timeout.

I looked at how the upgrade process should work on a standard js server/client chrome request sniffer.
When the server sends the upgrade response, it also sends a NOOP on the polling transport. This closes the xhr connection and seems to allow the client to finish the websocket upgrade.

