### PR TITLE
Fixing concurrency and thread issues in engine.io

### DIFF
--- a/engine.io-server-jetty/src/main/java/io/socket/engineio/server/JettyWebSocketHandler.java
+++ b/engine.io-server-jetty/src/main/java/io/socket/engineio/server/JettyWebSocketHandler.java
@@ -46,8 +46,8 @@ public final class JettyWebSocketHandler extends EngineIoWebSocket implements We
 
     @Override
     public void close() {
-        assert mSession != null;
-        mSession.close();
+        if (mSession != null)
+            mSession.close();
     }
 
     /* WebSocketListener */

--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServer.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServer.java
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -23,7 +24,7 @@ import java.util.TreeMap;
 @SuppressWarnings("WeakerAccess")
 public final class EngineIoServer extends Emitter {
 
-    private final Map<String, EngineIoSocket> mClients = new TreeMap<>();
+    private final Map<String, EngineIoSocket> mClients = Collections.synchronizedSortedMap(new TreeMap<>());
 
     private final EngineIoServerOptions mOptions;
 

--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServer.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServer.java
@@ -3,8 +3,8 @@ package io.socket.engineio.server;
 import io.socket.emitter.Emitter;
 import io.socket.engineio.server.transport.Polling;
 import io.socket.engineio.server.transport.WebSocket;
-import io.socket.yeast.ServerYeast;
 import io.socket.parseqs.ParseQS;
+import io.socket.yeast.ServerYeast;
 import org.json.JSONObject;
 
 import javax.servlet.http.HttpServletRequest;
@@ -12,9 +12,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The engine.io server.
@@ -24,7 +23,7 @@ import java.util.TreeMap;
 @SuppressWarnings("WeakerAccess")
 public final class EngineIoServer extends Emitter {
 
-    private final Map<String, EngineIoSocket> mClients = Collections.synchronizedSortedMap(new TreeMap<>());
+    private final Map<String, EngineIoSocket> mClients = new ConcurrentHashMap<>();
 
     private final EngineIoSocketTimeoutHandler mPingTimeoutHandler;
 

--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServer.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServer.java
@@ -26,6 +26,9 @@ public final class EngineIoServer extends Emitter {
 
     private final Map<String, EngineIoSocket> mClients = Collections.synchronizedSortedMap(new TreeMap<>());
 
+    private final EngineIoSocketTimeoutHandler mPingTimeoutHandler;
+
+
     private final EngineIoServerOptions mOptions;
 
     /**
@@ -44,6 +47,7 @@ public final class EngineIoServer extends Emitter {
     public EngineIoServer(EngineIoServerOptions options) {
         mOptions = options;
         mOptions.lock();
+        mPingTimeoutHandler = new EngineIoSocketTimeoutHandler(mOptions.getMaxTimeoutThreadPoolSize());
     }
 
     /**
@@ -183,7 +187,7 @@ public final class EngineIoServer extends Emitter {
         final String sid = ServerYeast.yeast();
 
         final Transport transport = new Polling();
-        final EngineIoSocket socket = new EngineIoSocket(sid, this);
+        final EngineIoSocket socket = new EngineIoSocket(sid, this, mPingTimeoutHandler);
         socket.init(transport, request);
         transport.onRequest(request, response);
 
@@ -197,7 +201,7 @@ public final class EngineIoServer extends Emitter {
         final String sid = ServerYeast.yeast();
 
         final Transport transport = new WebSocket(webSocket);
-        final EngineIoSocket socket = new EngineIoSocket(sid, this);
+        final EngineIoSocket socket = new EngineIoSocket(sid, this, mPingTimeoutHandler);
         socket.init(transport, null);
 
         mClients.put(sid, socket);

--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServerOptions.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoServerOptions.java
@@ -36,6 +36,7 @@ public final class EngineIoServerOptions {
         DEFAULT.setPingTimeout(5000);
         DEFAULT.setPingInterval(25000);
         DEFAULT.setAllowedCorsOrigins(ALLOWED_CORS_ORIGIN_ALL);
+        DEFAULT.setMaxTimeoutThreadPoolSize(20);
         DEFAULT.lock();
     }
 
@@ -45,6 +46,7 @@ public final class EngineIoServerOptions {
     private long mPingTimeout;
     private String[] mAllowedCorsOrigins;
     private Packet mInitialPacket;
+    private int mMaxTimeoutThreadPoolSize;
 
     private EngineIoServerOptions() {
         mIsLocked = false;
@@ -62,6 +64,7 @@ public final class EngineIoServerOptions {
                 .setPingInterval(DEFAULT.getPingInterval())
                 .setPingTimeout(DEFAULT.getPingTimeout())
                 .setAllowedCorsOrigins(DEFAULT.getAllowedCorsOrigins())
+                .setMaxTimeoutThreadPoolSize(DEFAULT.getMaxTimeoutThreadPoolSize())
                 .setInitialPacket(null);
     }
 
@@ -218,5 +221,31 @@ public final class EngineIoServerOptions {
      */
     public void lock() {
         mIsLocked = true;
+    }
+
+
+    /**
+     * Gets the max threadpool size for the ping timeout timers.
+     *
+     * @return Max threadpool size for ping timeout timers.
+     */
+    public int getMaxTimeoutThreadPoolSize() {
+        return mMaxTimeoutThreadPoolSize;
+    }
+
+    /**
+     * Sets the max threadpool size for the ping timeout timers.
+     *
+     * @param maxTimeoutThreadPoolSize Max threadpool size for handling ping timeouts.
+     * @return Instance for chaining.
+     * @throws IllegalStateException If instance is locked.
+     */
+    public EngineIoServerOptions setMaxTimeoutThreadPoolSize(int maxTimeoutThreadPoolSize) throws IllegalStateException {
+        if (mIsLocked) {
+            throw new IllegalStateException("Max timeout thread pool size cannot be set. Instance is locked.");
+        }
+
+        mMaxTimeoutThreadPoolSize = maxTimeoutThreadPoolSize;
+        return this;
     }
 }

--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
@@ -32,6 +32,7 @@ public final class EngineIoSocket extends Emitter {
     private final String mSid;
     private final EngineIoServer mServer;
     private final LinkedList<Packet> mWriteBuffer = new LinkedList<>();
+    private final Runnable mPingTimeoutTask = () -> onClose("ping timeout", null);
 
     private final EngineIoSocketTimeoutHandler mPingTimeoutHandler;
     private ScheduledFuture mPingTimerScheduledReference = null;
@@ -308,15 +309,13 @@ public final class EngineIoSocket extends Emitter {
         }
     }
 
-    private void resetPingTimeout() {
+    private synchronized void resetPingTimeout() {
         if(mPingTimerScheduledReference != null) {
             mPingTimerScheduledReference.cancel(false);
         }
 
-        Runnable pingTimeoutTask = () -> onClose("ping timeout", null);
-
         mPingTimerScheduledReference = mPingTimeoutHandler.schedule(
-                pingTimeoutTask,
+                mPingTimeoutTask,
                 mServer.getOptions().getPingInterval() + mServer.getOptions().getPingTimeout(),
                 TimeUnit.MILLISECONDS);
     }

--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocketTimeoutHandler.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocketTimeoutHandler.java
@@ -1,0 +1,74 @@
+package io.socket.engineio.server;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class EngineIoSocketTimeoutHandler {
+
+    private final ExecutorService executorPool;
+    private final ScheduledExecutorService scheduledExecutorService;
+
+    /**
+     * Constructs a new socket timeout handler.
+     * The purpose of this class is to dynamically handle concurrent timeout tasks using
+     * a resource efficient thread pool.
+     *
+     * The {@link ScheduledExecutorService} can't have a dynamic expanding/contracting thread pool
+     * so the task is sent to a {@link ThreadPoolExecutor) for execution once the timeout occurs.
+     *
+     * The two {@link EngineIoThreadFactory} instances are used to name the threads appropriately.
+     *
+     * @param maxThreadPoolSize The maximum thread pool size to expand to
+     */
+    EngineIoSocketTimeoutHandler(int maxThreadPoolSize) {
+        scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(new EngineIoThreadFactory("scheduler"));
+
+        executorPool = new ThreadPoolExecutor(
+                1,
+                maxThreadPoolSize,
+                60L,
+                TimeUnit.SECONDS,
+                new SynchronousQueue<>(true),
+                new EngineIoThreadFactory("pool"),
+                new ThreadPoolExecutor.CallerRunsPolicy());
+    }
+
+
+    /**
+     * Schedules the socketTimeoutTask on the executorScheduler.
+     * Upon the scheduler timeout, the task will be posted to the dynamic executorPool for execution.
+     *
+     * @param socketTimeoutTask The task to schedule on the pool
+     * @param timeout The timeout of the task
+     * @param timeUnit The TimeUnit of the timeout
+     *
+     * @return The {@link ScheduledFuture} to enable cancellation of the task before its timeout
+     */
+    ScheduledFuture schedule(Runnable socketTimeoutTask, long timeout, TimeUnit timeUnit) {
+        Runnable executorTask = () -> executorPool.execute(socketTimeoutTask);
+        return scheduledExecutorService.schedule(executorTask, timeout, timeUnit);
+    }
+
+
+    /**
+     * {@link ThreadFactory} for naming the thread pool threads with appropriate names
+     */
+    private static class EngineIoThreadFactory implements ThreadFactory {
+
+        private AtomicInteger count = new AtomicInteger();
+        private String mGroupNamePostfix;
+
+        EngineIoThreadFactory(String groupNamePostfix) {
+            mGroupNamePostfix = groupNamePostfix;
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread thread = new Thread(r);
+            thread.setName(String.format("engineIo-socketTimeout-%s-%d", mGroupNamePostfix, count.incrementAndGet()));
+            thread.setDaemon(true);
+            return thread;
+        }
+    }
+
+}

--- a/engine.io-server/src/test/java/io/socket/engineio/server/EngineIoSocketTest.java
+++ b/engine.io-server/src/test/java/io/socket/engineio/server/EngineIoSocketTest.java
@@ -43,10 +43,12 @@ public final class EngineIoSocketTest {
         }
     }
 
+    private EngineIoSocketTimeoutHandler mPingTimeoutHandler = new EngineIoSocketTimeoutHandler(1);
+
     @Test
     public void testInit() {
         final Transport transport = Mockito.spy(new StubTransport());
-        final EngineIoSocket socket = Mockito.spy(new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer()));
+        final EngineIoSocket socket = Mockito.spy(new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler));
 
         Mockito.doAnswer(invocationOnMock -> {
             final List<Packet> packetList = invocationOnMock.getArgument(0);
@@ -80,7 +82,7 @@ public final class EngineIoSocketTest {
                 .setInitialPacket(initialPacket);
 
         final Transport transport = Mockito.spy(new StubTransport());
-        final EngineIoSocket socket = Mockito.spy(new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(options)));
+        final EngineIoSocket socket = Mockito.spy(new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(options), mPingTimeoutHandler));
 
         Mockito.doAnswer(invocationOnMock -> {
             final List<Packet> packetList = invocationOnMock.getArgument(0);
@@ -101,7 +103,7 @@ public final class EngineIoSocketTest {
     @Test
     public void testOnRequest() throws IOException {
         final Transport transport = Mockito.spy(new StubTransport());
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport, null);
 
         final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
@@ -117,7 +119,7 @@ public final class EngineIoSocketTest {
     @Test
     public void testSend() {
         final Transport transport = Mockito.spy(new StubTransport());
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport, null);
 
         final Packet<String> packet = new Packet<>(Packet.MESSAGE, "TestMessage");
@@ -140,7 +142,7 @@ public final class EngineIoSocketTest {
     @Test
     public void testSend_delayed() {
         final Transport transport = Mockito.spy(new StubTransport());
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport, null);
 
         Mockito.doAnswer(invocationOnMock -> false).when(transport).isWritable();
@@ -171,7 +173,7 @@ public final class EngineIoSocketTest {
     @Test
     public void testClose_withoutData() {
         final Transport transport = Mockito.spy(new StubTransport());
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport, null);
 
         socket.close();
@@ -187,7 +189,7 @@ public final class EngineIoSocketTest {
     @Test
     public void testClose_withData() {
         final Transport transport = Mockito.spy(new StubTransport());
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport, null);
 
         Mockito.doAnswer(invocationOnMock -> false).when(transport).isWritable();
@@ -220,7 +222,7 @@ public final class EngineIoSocketTest {
     public void testCanUpgrade() {
         final Transport transport = Mockito.spy(new StubTransport());
         final EngineIoServer server = new EngineIoServer();
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), server);
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), server, mPingTimeoutHandler);
         socket.init(transport, null);
 
         Mockito.doAnswer(invocationOnMock -> Polling.NAME).when(transport).getName();
@@ -234,7 +236,7 @@ public final class EngineIoSocketTest {
         final EngineIoServer server = new EngineIoServer(EngineIoServerOptions.newFromDefault()
                 .setPingInterval(1500)
                 .setPingTimeout(3000));
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), server);
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), server, mPingTimeoutHandler);
         socket.init(transport, null);
 
         final Emitter.Listener closeListener = Mockito.mock(Emitter.Listener.class);
@@ -251,7 +253,7 @@ public final class EngineIoSocketTest {
     @Test
     public void testTransportClose() {
         final Transport transport = Mockito.spy(new StubTransport());
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport, null);
 
         final Emitter.Listener closeListener = Mockito.mock(Emitter.Listener.class);
@@ -268,7 +270,7 @@ public final class EngineIoSocketTest {
     @Test
     public void testTransportError() {
         final Transport transport = Mockito.spy(new StubTransport());
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport, null);
 
         final Emitter.Listener closeListener = Mockito.mock(Emitter.Listener.class);
@@ -285,7 +287,7 @@ public final class EngineIoSocketTest {
     @Test
     public void testTransportPacket() {
         final Transport transport = Mockito.spy(new StubTransport());
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport, null);
 
         final Packet<String> packet = new Packet<>(Packet.NOOP);
@@ -301,7 +303,7 @@ public final class EngineIoSocketTest {
     @Test
     public void testTransportPacket_message() {
         final Transport transport = Mockito.spy(new StubTransport());
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport, null);
 
         final String packetData = "TestMessage";
@@ -328,7 +330,7 @@ public final class EngineIoSocketTest {
     @Test
     public void testTransportPacket_ping() {
         final Transport transport = Mockito.spy(new StubTransport());
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport, null);
 
         final Packet<String> packet = new Packet<>(Packet.PING);
@@ -353,7 +355,7 @@ public final class EngineIoSocketTest {
     @Test
     public void testTransportPacket_error() {
         final Transport transport = Mockito.spy(new StubTransport());
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport, null);
 
         final Packet<String> packet = new Packet<>(Packet.ERROR);
@@ -374,7 +376,7 @@ public final class EngineIoSocketTest {
         final Transport transport1 = Mockito.spy(new StubTransport());
         Mockito.doAnswer(invocationOnMock -> Polling.NAME).when(transport1).getName();
 
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport1, null);
 
         final Transport transport2 = Mockito.spy(new StubTransport());
@@ -410,7 +412,7 @@ public final class EngineIoSocketTest {
         final Transport transport1 = Mockito.spy(new StubTransport());
         Mockito.doAnswer(invocationOnMock -> Polling.NAME).when(transport1).getName();
 
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport1, null);
 
         final Transport transport2 = Mockito.spy(new StubTransport());
@@ -444,7 +446,7 @@ public final class EngineIoSocketTest {
         final Transport transport1 = Mockito.spy(new StubTransport());
         Mockito.doAnswer(invocationOnMock -> Polling.NAME).when(transport1).getName();
 
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport1, null);
 
         final Transport transport2 = Mockito.spy(new StubTransport());
@@ -465,7 +467,7 @@ public final class EngineIoSocketTest {
         final Transport transport1 = Mockito.spy(new StubTransport());
         Mockito.doAnswer(invocationOnMock -> Polling.NAME).when(transport1).getName();
 
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport1, null);
 
         final Transport transport2 = Mockito.spy(new StubTransport());
@@ -485,7 +487,7 @@ public final class EngineIoSocketTest {
         final Transport transport1 = Mockito.spy(new StubTransport());
         Mockito.doAnswer(invocationOnMock -> Polling.NAME).when(transport1).getName();
 
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport1, null);
 
         final Transport transport2 = Mockito.spy(new StubTransport());
@@ -505,7 +507,7 @@ public final class EngineIoSocketTest {
         final Transport transport1 = Mockito.spy(new StubTransport());
         Mockito.doAnswer(invocationOnMock -> Polling.NAME).when(transport1).getName();
 
-        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer());
+        final EngineIoSocket socket = new EngineIoSocket(ServerYeast.yeast(), new EngineIoServer(), mPingTimeoutHandler);
         socket.init(transport1, null);
 
         final Transport transport2 = Mockito.spy(new StubTransport());


### PR DESCRIPTION
Hi,
I spent a few weeks investigating and load testing the engine.io-java server for a project. During this time I found and fixed several issues to do with concurrency, race conditions and the TimerTasks.
In the end I decided not to continue with engine.io but thought I'd push up my fixes that I found.

Hope this helps.