### PR TITLE
Remove redundant resetPingTimeout for engine.io v4

### DIFF
--- a/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/EngineIoSocket.java
@@ -299,8 +299,6 @@ public final class EngineIoSocket extends Emitter {
         if(mReadyState == ReadyState.OPEN) {
             emit("packet", packet);
 
-            resetPingTimeout();
-
             switch (packet.type) {
                 case Packet.PONG:
                     schedulePing();


### PR DESCRIPTION
All resetPingTimeout()  invocation should in the sendPing() method.