### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - name: "Java 8 Tests"
       jdk: openjdk8
       env: TESTENV=tests
-      script: travis_retry mvn test
+      script: mvn test
     - name: "GitHub Pages"
       jdk: openjdk8
       env: TESTENV=cover FYI="this also builds documentation for tags"
@@ -34,3 +34,7 @@ matrix:
 
 after_success:
   - '[[ "$TESTENV" == "tests" ]] && bash <(curl -s https://codecov.io/bash) -f engine.io-server-coverage/target/site/jacoco-aggregate/jacoco.xml'
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
