### PR TITLE
Update version of Jetty

### DIFF
--- a/engine.io-server-coverage/pom.xml
+++ b/engine.io-server-coverage/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>engine.io-server-bom</artifactId>
         <groupId>io.socket</groupId>
-        <version>6.2.1</version>
+        <version>6.3.0</version>
     </parent>
 
     <artifactId>engine.io-server-coverage</artifactId>

--- a/engine.io-server-jetty/pom.xml
+++ b/engine.io-server-jetty/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.socket</groupId>
         <artifactId>engine.io-server-bom</artifactId>
-        <version>6.2.1</version>
+        <version>6.3.0</version>
     </parent>
 
     <artifactId>engine.io-server-jetty</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-api</artifactId>
-            <version>9.4.24.v20191120</version>
+            <version>9.4.50.v20221201</version>
             <scope>provided</scope>
         </dependency>
 
@@ -43,13 +43,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.1</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>3.12.1</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -121,7 +121,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.8</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/engine.io-server-test/pom.xml
+++ b/engine.io-server-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.socket</groupId>
         <artifactId>engine.io-server-bom</artifactId>
-        <version>6.2.1</version>
+        <version>6.3.0</version>
     </parent>
 
     <artifactId>engine.io-server-test</artifactId>
@@ -40,19 +40,19 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.24.v20191120</version>
+            <version>9.4.50.v20221201</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.24.v20191120</version>
+            <version>9.4.50.v20221201</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-server</artifactId>
-            <version>9.4.24.v20191120</version>
+            <version>9.4.50.v20221201</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -132,6 +132,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <argLine>-Dfile.encoding=UTF-8</argLine>
                     <systemPropertyVariables>
                         <java.util.logging.config.file>./src/test/resources/logging.properties</java.util.logging.config.file>

--- a/engine.io-server-test/src/test/java/io/socket/engineio/server/ServerWrapper.java
+++ b/engine.io-server-test/src/test/java/io/socket/engineio/server/ServerWrapper.java
@@ -7,6 +7,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.websocket.server.NativeWebSocketServletContainerInitializer;
 import org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter;
 
 import javax.servlet.ServletException;
@@ -71,10 +72,13 @@ final class ServerWrapper {
         }), "/*");
 
         try {
-            WebSocketUpgradeFilter webSocketUpgradeFilter = WebSocketUpgradeFilter.configure(servletContextHandler);
-            webSocketUpgradeFilter.addMapping(
-                    new ServletPathSpec("/engine.io/*"),
-                    (servletUpgradeRequest, servletUpgradeResponse) -> new JettyWebSocketHandler(mEngineIoServer));
+            WebSocketUpgradeFilter.configure(servletContextHandler);
+            NativeWebSocketServletContainerInitializer.configure(servletContextHandler, (ctx, container) -> {
+                container.addMapping(
+                        new ServletPathSpec("/engine.io/*"),
+                        (servletUpgradeRequest, servletUpgradeResponse) -> new JettyWebSocketHandler(mEngineIoServer)
+                );
+            });
         } catch (ServletException ex) {
             ex.printStackTrace();
         }

--- a/engine.io-server/pom.xml
+++ b/engine.io-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.socket</groupId>
         <artifactId>engine.io-server-bom</artifactId>
-        <version>6.2.1</version>
+        <version>6.3.0</version>
     </parent>
 
     <artifactId>engine.io-server</artifactId>
@@ -38,13 +38,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.1</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>3.12.1</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -159,7 +159,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.8</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.socket</groupId>
     <artifactId>engine.io-server-bom</artifactId>
-    <version>6.2.1</version>
+    <version>6.3.0</version>
     <packaging>pom</packaging>
     <name>engine.io</name>
     <description>Engine.IO server library for Java</description>


### PR DESCRIPTION
This PR updates the version of Jetty to `9.4.50.v20221201` from `9.4.24.v20191120`, alongside updates to some other testing libraries to support more recent versions of Java. This also required a change to the ServerWrapper test class due to changes in newer versions of Jetty.