### PR TITLE
Handle V4 base64 packets with line breaks gracefully

### DIFF
--- a/engine.io-server/src/main/java/io/socket/engineio/server/parser/ParserV4.java
+++ b/engine.io-server/src/main/java/io/socket/engineio/server/parser/ParserV4.java
@@ -114,7 +114,8 @@ public final class ParserV4 implements Parser {
             final String stringData = (String) data;
             if(stringData.charAt(0) == 'b') {
                 final Packet<byte[]> packet = new Packet<>(Packet.MESSAGE);
-                packet.data = java.util.Base64.getDecoder().decode(stringData.substring(1));
+                // Ignore line breaks, added by engine.io-client-java during base64 encode
+                packet.data = java.util.Base64.getDecoder().decode(stringData.substring(1).replace("\n", ""));
                 return packet;
             } else {
                 final Packet<String> packet = new Packet<>(PACKETS_REVERSE.get(

--- a/engine.io-server/src/test/java/io/socket/engineio/server/parser/ParserV4Test.java
+++ b/engine.io-server/src/test/java/io/socket/engineio/server/parser/ParserV4Test.java
@@ -204,6 +204,16 @@ public final class ParserV4Test {
             assertEquals(byte[].class, packetDecoded.data.getClass());
             assertArrayEquals(packetOriginal.data, (byte[]) packetDecoded.data);
         });
+
+        // Other socket.io libraries may add a line break to their base64 encoded output
+        final Packet<byte[]> packetOriginalLineBreak = new Packet<>(Packet.MESSAGE, "Engine.IO".getBytes(StandardCharsets.UTF_8));
+        Parser.PROTOCOL_V4.encodePacket(packetOriginalLineBreak, false, data -> {
+            data += "\n";
+            Packet<?> packetDecoded = Parser.PROTOCOL_V4.decodePacket(data);
+            assertEquals(Packet.MESSAGE, packetDecoded.type);
+            assertEquals(byte[].class, packetDecoded.data.getClass());
+            assertArrayEquals(packetOriginal.data, (byte[]) packetDecoded.data);
+        });
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Some socket.io client libraries, such as engine.io-client-java, include a line break in the base64 encoded binary V4 packets. Other server implementations (such as the nodejs module) handle this gracefully, this one currently throws an exception due to that unexpected char.

Adding logic to handle that gracefully since other servers do it, and to be compatible with older versions of libraries even if we were to change that behavior in the client.

engine.io-client-java reference (if they passed Base64.NO_WRAP we'd be fine...)
https://github.com/socketio/engine.io-client-java/blob/8519952a51baff36a2844d726876266b37ad6ffe/src/main/java/io/socket/engineio/parser/Parser.java#L46C21-L46C21

Note: There might be a better place earlier in the packet parsing logic that's more appropriate to handle this, I haven't read through the earlier stages, hoping someone can advise on that.